### PR TITLE
Bump FRC version, support long version codes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
 name: Publish Bintray
 
 on:
-  create:
+  push:
     tags:
-      - v*
+      - '*'
     
 jobs:
   build:

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -25,7 +25,7 @@ object Dependencies {
     const val coreKtx = "androidx.core:core-ktx:$coreKtxVersion"
 
     // Firebase
-    private const val firebaseConfigVersion = "19.1.4"
+    private const val firebaseConfigVersion = "20.0.3"
     const val firebaseConfig = "com.google.firebase:firebase-config:$firebaseConfigVersion"
 
     // Retrofit

--- a/firebase-fetcher/src/main/java/com/ackee/versionupdatehandler/FirebaseVersionFetcher.kt
+++ b/firebase-fetcher/src/main/java/com/ackee/versionupdatehandler/FirebaseVersionFetcher.kt
@@ -31,8 +31,7 @@ class FirebaseVersionFetcher(
         val remoteConfig = FirebaseRemoteConfig.getInstance().apply {
             setDefaultsAsync(DEFAULTS)
         }
-        val isDevMode = FirebaseRemoteConfig.getInstance().info.configSettings.isDeveloperModeEnabled
-        remoteConfig.fetch((if (isDevMode) 0 else cacheExpiration).toLong()).await()
+        remoteConfig.fetch(cacheExpiration.toLong()).await()
         remoteConfig.activate().await()
 
         val minimalVersion = remoteConfig.getLong(minimalAttributeName)

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-VERSION_NAME=2.0.0
+VERSION_NAME=2.0.1
 VERSION_CODE=1
 GROUP=cz.ackee.updatechecker
 BINTRAY_REPO=version-update-handler

--- a/status-resolver/src/main/java/com/ackee/versioupdatehandler/VersionStatusResolver.kt
+++ b/status-resolver/src/main/java/com/ackee/versioupdatehandler/VersionStatusResolver.kt
@@ -1,6 +1,5 @@
 package com.ackee.versioupdatehandler
 
-import android.util.Log
 import androidx.fragment.app.FragmentManager
 import com.ackee.versioupdatehandler.model.DialogSettings
 import com.ackee.versioupdatehandler.model.VersionStatus
@@ -12,11 +11,15 @@ import com.ackee.versioupdatehandler.model.VersionsConfiguration
 class VersionStatusResolver(private val fetcher: VersionFetcher) {
 
     suspend fun checkVersionStatus(version: Int): VersionStatus {
+        return checkVersionStatus(version.toLong())
+    }
+
+    suspend fun checkVersionStatus(version: Long): VersionStatus {
         val versionConfig = fetcher.fetch()
         return resolveStatus(version, versionConfig)
     }
 
-    private fun resolveStatus(version: Int, configuration: VersionsConfiguration): VersionStatus {
+    private fun resolveStatus(version: Long, configuration: VersionsConfiguration): VersionStatus {
         var status = VersionStatus.UP_TO_DATE
         if (version < configuration.minimalVersion()) {
             status = VersionStatus.UPDATE_REQUIRED


### PR DESCRIPTION
1. Bumped FRC version to the latest
1.1. Removed deprecated (and already removed) property
2. Support for Long version codes Fixes #6 
3. Upload to bintray on every tag